### PR TITLE
Fix deployment to Github Pages after upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,13 +15,22 @@ jobs:
         uses: withastro/action@v1.0.6
         with:
           package-manager: bun@latest
+      - name: Upload artifact
+        id: github-pages
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'github-pages'
+          path: 'dist'
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write 
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
**CHANGELOG**
- Fix deployment to GitHub Pages after upgrade to version 4. [Issue](https://github.com/actions/deploy-pages/issues/305)